### PR TITLE
Make regexp matching mirror lines more lax

### DIFF
--- a/moddb/boxes.py
+++ b/moddb/boxes.py
@@ -1204,7 +1204,7 @@ class Mirror:
         The index of the mirror, as multiple mirrors
         have the same name. Index starts at 1
     city : str
-        Alpha 2 code for the city the server is located
+        Alpha 2 code, or full name, of the city the server is located
         in
     country : str
         Alpha 2 code for the country the server is

--- a/moddb/pages/file.py
+++ b/moddb/pages/file.py
@@ -169,7 +169,7 @@ class File(BaseMetaClass):
         mirrors_div = html.find("div", class_="mirrors").find_all("div", recursive=False)
         mirrors = []
         for mirror in mirrors_div:
-            mirror_match = re.match(r"(.*) #([0-9]*) \((.{2}), (.{2})\)", mirror.div.p.contents[-1].strip())
+            mirror_match = re.match(r"(.*) #([0-9]*) \((\w+), (.{2})\)", mirror.div.p.contents[-1].strip())
             stats_match = re.match(
                 r"([0-9,]*) downloads? served, ([0-9.]*)% capacity",
                 mirror.div.span.string,


### PR DESCRIPTION
Some mirrors would not be matched by the regex, and would result in a crash because the code tries to then look into capture groups.

Fixes #25 

Signed-off-by: Antoine Mazeas <antoine@karthanis.net>