### PR TITLE
allow newer versions of libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ setup(
     long_description=readme,
     packages=find_packages(include=['moddb', 'moddb.*']),
     install_requires=[
-        'beautifulsoup4 == 4.6.3',
-        'requests>=2.20.0',
-        'toolz == 0.11.2',
-        'pyrate-limiter==2.8.1'
+        'beautifulsoup4 >= 4.6.3',
+        'requests >= 2.20.0',
+        'toolz >= 0.11.2',
+        'pyrate-limiter >= 2.8.1'
       ]
     )


### PR DESCRIPTION
Hi. I am packaging this for the Fedora project as it will soon be a dependency for Lutris, which I am the package maintainer of. We don't package the exact versions in setup.py, but instead newer versions, so we have had to patch setup.py to get it to build in Fedora.

If you don't think this will break functionality in your library, maybe you could also merge this into the next version of your library?