### PR TITLE
utils.py: Catch request's own JSONDecodeError exception in raise_for_status()

### DIFF
--- a/moddb/utils.py
+++ b/moddb/utils.py
@@ -5,7 +5,6 @@ from .errors import ModdbException, AwaitingAuthorisation
 import re
 import sys
 import uuid
-import json
 import random
 import inspect
 import logging
@@ -150,7 +149,7 @@ def raise_for_status(response):
             LOGGER.error(response.request.url)
             LOGGER.error(response.request.body)
             raise ModdbException(text["text"])
-    except json.decoder.JSONDecodeError:
+    except requests.exceptions.JSONDecodeError:
         response.raise_for_status()
 
     if (


### PR DESCRIPTION
The following might be incorrect due to my unfamiliarity with both Python and this library, but it allowed me to get it to work on Solus:

`request` has it's own alias for both `simplejson` and `json` decode errors
```
        except JSONDecodeError as e:
            # Catch JSON-related errors and raise as requests.JSONDecodeError
            # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
```
Using it avoids uncaught errors disrupting the control flow on systems using `simplejson` (as the except clause doesn't catch `simplejson` exceptions in it's current form)