### PR TITLE
Lower log level for ID retrieval failure

### DIFF
--- a/moddb/pages/base.py
+++ b/moddb/pages/base.py
@@ -69,7 +69,7 @@ class BaseMetaClass:
                 self.id = func()
                 break
             except (AttributeError, TypeError) as e:
-                LOGGER.warning(
+                LOGGER.info(
                     "Failed to get id from method %s for member %s: %s", index, self.name, e
                 )
         else:


### PR DESCRIPTION
There is no need for logging a warning. An error will raise anyway if the ID retrieval fails.