### PR TITLE
Clear freeman cookie on unsuccessful login

### DIFF
--- a/moddb/utils.py
+++ b/moddb/utils.py
@@ -266,6 +266,7 @@ def login_with_freeman_cookie(freeman_cookie: str, session: requests.Session = N
     session.cookies.set("freeman", freeman_cookie, domain="www.moddb.com", path="/")
     member_nameid = get_logged_in_member_nameid(session)
     if member_nameid is None:
+        session.cookies.clear(domain="www.moddb.com", path="/", name="freeman")
         raise ValueError("Invalid freeman cookie")
 
     return member_nameid


### PR DESCRIPTION
I forgot to clear the cookie again if the login is not successful. Without this `moddb.get_freeman_cookie()` can return an invalid cookie.